### PR TITLE
Close #45: queue-based analysis orchestration (M2 layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,56 @@ extShiftLex getEdges myTriangulation
 
 ## How to run the iterative analysis
 
-1. Create a config file (e.g. `my_config.m2`) containing:
+The queue-based analysis stores each pending triangulation as its own file, so it survives interruption and can be resumed at any time.
+
+### Worked example — irreducible tori
+
+1. Create a config file (e.g. `my_config.m2`):
 
    ```
-   analysisName = "my-analysis"
-   analysisInputFile = "/absolute/path/to/input.m2"
+   analysisName = "tori-analysis"
+   analysisInputFile = "/absolute/path/to/data/surface triangulations/irredTori.m2"
    ```
 
-   The input file is a list of triangulations. You can use the provided input files under `data/surface triangulations/` (e.g. `irredTori.m2`, `irredKb.m2`, `irredPp.m2`).
-
-2. Open a terminal in the root of the cloned repository and run:
+2. Run the queue orchestrator from the root of the cloned repository:
 
    ```
-   M2 --script scripts/runAnalysis.m2 /absolute/path/to/my_config.m2
+   M2 --script scripts/runQueue.m2 /absolute/path/to/my_config.m2
    ```
 
-3. M2 exits with code **0** when the analysis has converged (no more splits to calculate), or code **1** if another iteration is needed. Repeat step 2 until M2 exits with code 0.
+   The script processes triangulations one at a time, printing structured lifecycle events (`EVENT:{...}`) alongside raw M2 output, until the queue is empty (convergence).
 
-4. Results are written to `analysis output/<analysisName>/`. Each `iteration_<n>/` folder contains summary files with the findings of that iteration.
+3. Results are written to `analysis output/<analysisName>/`. Processed items accumulate in `done/` and unprocessed items remain in `pending/`.
+
+### Resuming a paused run
+
+Run the same command again — `initQueueEnv.m2` detects the existing `pending/` directory and skips re-seeding, so the run continues from where it left off:
+
+```
+M2 --script scripts/runQueue.m2 /absolute/path/to/my_config.m2
+```
+
+### Batch caps
+
+Pass optional caps as positional arguments after the config path (use `null` to skip a cap):
+
+```
+M2 --script scripts/runQueue.m2 /absolute/path/to/my_config.m2 <itemCap> <maxVertexCount> <timeoutSeconds>
+```
+
+| Argument | Effect |
+|---|---|
+| `itemCap` | Stop after processing this many triangulations |
+| `maxVertexCount` | Stop before processing a triangulation with more vertices than this |
+| `timeoutSeconds` | Stop after this many wall-clock seconds (never mid-item) |
+
+Example — process at most 10 items, no other caps:
+
+```
+M2 --script scripts/runQueue.m2 /absolute/path/to/my_config.m2 10 null null
+```
+
+The script emits `EVENT:{"type":"run_paused"}` when a cap stops the run, or `EVENT:{"type":"run_complete"}` when the queue empties naturally.
 
 ## Functions to know
 

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -280,3 +280,39 @@ TEST ///
   assert(result === "complete")
   assert(0 == #select(readDirectory pendingDir, f -> f != "." and f != ".."))
 ///
+
+TEST ///
+  -- runQueue accepts all four options without error when cap variables are
+  -- given distinct names that do not shadow the option symbols.
+  -- Guards against the bug where := bindings named itemCap / maxVertexCount /
+  -- timeoutSeconds shadow those symbols, causing null => null options and an
+  -- "unknown key or option" error at the call site.
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pd := concatenate(tmpBase, "/pending");
+  dd := concatenate(tmpBase, "/done");
+  mkdir pd; mkdir dd;
+  toriAll := value get "data/surface triangulations/irredTori.m2";
+  writeQueueItem(concatenate(pd, "/0001"), "seed", 0, 1, toriAll_0);
+  capItem := 1;
+  capMaxVerts := null;
+  capTimeout := null;
+  result := runQueue(pd, dd,
+      itemCap => capItem, maxVertexCount => capMaxVerts,
+      timeoutSeconds => capTimeout, exemptions => new HashTable from {});
+  assert(result === "paused")
+///
+
+TEST ///
+  -- initQueueEnv uses analysisOutputDir (absolute path) as outputDirPath
+  -- This guards against the relative-path bug where M2 and C# disagree on
+  -- where pending/ and done/ live.
+  tmpBase := temporaryFileName();
+  analysisOutputDir = tmpBase;
+  analysisName = "test-run";
+  analysisInputFile = "data/surface triangulations/irredTori.m2";
+  load "scripts/initQueueEnv.m2";
+  assert(outputDirPath === tmpBase)
+  assert(isDirectory concatenate(tmpBase, "/pending"))
+  assert(isDirectory concatenate(tmpBase, "/done"))
+///

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -1,0 +1,98 @@
+-- lib/queueOps.m2
+-- Queue file I/O for the persistent analysis queue.
+-- The queue lives in pending/ and done/ subdirectories under a run output directory.
+-- Each file encodes one triangulation plus provenance metadata as an M2 HashTable.
+
+-- Returns a zero-padded decimal string of integer n to the given width.
+-- Example: queueSeqStr(3, 4) => "0003"
+queueSeqStr = (n, width) -> (
+    s := toString n;
+    concatenate(apply(max(0, width - #s), j -> "0"), s)
+);
+
+-- Writes a queue item file at path.
+-- File content is a readable M2 HashTable with keys:
+--   "parent"        => parent filename (or "seed" for items from the initial input)
+--   "depth"         => integer depth in the split tree (0 for seeds)
+--   "seq"           => integer sequence number
+--   "triangulation" => list of faces (list of vertex lists)
+writeQueueItem = (path, parent, depth, seq, tri) -> (
+    f := path << "new HashTable from {" << endl;
+    f << "  \"parent\" => " << toExternalString parent << "," << endl;
+    f << "  \"depth\" => " << toExternalString depth << "," << endl;
+    f << "  \"seq\" => " << toExternalString seq << "," << endl;
+    f << "  \"triangulation\" => " << toExternalString tri << endl;
+    f << "}" << close;
+);
+
+-- Reads a queue item file and returns the encoded HashTable.
+readQueueItem = path -> value get path;
+
+-- Initializes the queue directory structure under outputDir.
+-- First run: creates pending/ and done/, seeds pending/ with one file per
+--   triangulation from inputFile (zero-padded sequence filenames, depth 0, parent "seed").
+-- Resume: no-op if pending/ already exists.
+initQueue = (outputDir, inputFile) -> (
+    pendingDir := concatenate(outputDir, "/pending");
+    doneDir := concatenate(outputDir, "/done");
+    if isDirectory pendingDir then return;
+    mkdir pendingDir;
+    mkdir doneDir;
+    triangulations := value get inputFile;
+    for i from 0 to #triangulations - 1 do (
+        fname := concatenate(pendingDir, "/", queueSeqStr(i + 1, 4));
+        writeQueueItem(fname, "seed", 0, i + 1, triangulations_i);
+    );
+);
+
+TEST ///
+  -- initQueue creates pending/ and done/ subdirectories on first run
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  initQueue(tmpBase, "data/surface triangulations/irredTori.m2");
+  assert(isDirectory concatenate(tmpBase, "/pending"))
+  assert(isDirectory concatenate(tmpBase, "/done"))
+///
+
+TEST ///
+  -- initQueue seeds pending/ with one file per triangulation from input
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  inputFile := "data/surface triangulations/irredTori.m2";
+  triangulations := value get inputFile;
+  initQueue(tmpBase, inputFile);
+  pendingDir := concatenate(tmpBase, "/pending");
+  pendingFiles := select(readDirectory pendingDir, f -> f != "." and f != "..");
+  assert(#pendingFiles == #triangulations)
+///
+
+TEST ///
+  -- initQueue is a no-op on resume: pending/ already exists, no re-seeding
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pendingDir := concatenate(tmpBase, "/pending");
+  mkdir pendingDir;
+  concatenate(pendingDir, "/0001") << "dummy" << close;
+  initQueue(tmpBase, "data/surface triangulations/irredTori.m2");
+  pendingFiles := select(readDirectory pendingDir, f -> f != "." and f != "..");
+  assert(#pendingFiles == 1)
+///
+
+TEST ///
+  -- each seeded file is a readable HashTable with parent, depth, seq, triangulation
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  inputFile := "data/surface triangulations/irredTori.m2";
+  initQueue(tmpBase, inputFile);
+  pendingDir := concatenate(tmpBase, "/pending");
+  files := sort select(readDirectory pendingDir, f -> f != "." and f != "..");
+  item := readQueueItem concatenate(pendingDir, "/", files_0);
+  assert(instance(item, HashTable))
+  assert(item#?"parent")
+  assert(item#?"depth")
+  assert(item#?"seq")
+  assert(item#?"triangulation")
+  assert(item#"parent" === "seed")
+  assert(item#"depth" === 0)
+  assert(item#"seq" === 1)
+///

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -28,6 +28,64 @@ writeQueueItem = (path, parent, depth, seq, tri) -> (
 -- Reads a queue item file and returns the encoded HashTable.
 readQueueItem = path -> value get path;
 
+-- Returns the next available sequence number across pending/ and done/.
+-- Scans both directories and returns max existing seq number + 1.
+nextQueueSeq = (pendingDir, doneDir) -> (
+    pendingFiles := select(readDirectory pendingDir, f -> f != "." and f != "..");
+    doneFiles := select(readDirectory doneDir, f -> f != "." and f != "..");
+    allFiles := join(pendingFiles, doneFiles);
+    if #allFiles == 0 then 1
+    else max(apply(allFiles, f -> value f)) + 1
+);
+
+-- Emits a structured item_started event to stdout.
+emitItemStarted = (itemName, depth, parent) -> (
+    stdio << "EVENT:{\"type\":\"item_started\",\"item\":\"" | itemName |
+        "\",\"depth\":" | toString depth |
+        ",\"parent\":\"" | parent | "\"}" << endl;
+);
+
+-- Emits a structured item_done event to stdout.
+emitItemDone = (itemName, splitCount) -> (
+    stdio << "EVENT:{\"type\":\"item_done\",\"item\":\"" | itemName |
+        "\",\"splits\":" | toString splitCount | "}" << endl;
+);
+
+-- Processes the next item from pending/:
+--   reads the front item, runs analyzeIteration, enqueues resulting splits
+--   with provenance metadata, then moves the item to done/.
+-- Item is only moved to done/ after all split writes succeed.
+-- Optional: exemptions => HashTable of exempt splits (passed to analyzeIteration).
+-- Returns the number of splits produced.
+processQueueItem = {exemptions => new HashTable from {}} >> opts -> (pendingDir, doneDir) -> (
+    pendingFiles := sort select(readDirectory pendingDir, f -> f != "." and f != "..");
+    if #pendingFiles == 0 then return 0;
+    itemName := pendingFiles_0;
+    itemPath := concatenate(pendingDir, "/", itemName);
+    item := readQueueItem itemPath;
+    tri := item#"triangulation";
+    depth := item#"depth";
+    parent := item#"parent";
+
+    emitItemStarted(itemName, depth, parent);
+
+    (critRegions, splits, largest) := analyzeIteration({tri}, exemptions => opts.exemptions);
+
+    nextSeq := nextQueueSeq(pendingDir, doneDir);
+    for i from 0 to #splits - 1 do (
+        seq := nextSeq + i;
+        fname := concatenate(pendingDir, "/", queueSeqStr(seq, 4));
+        writeQueueItem(fname, itemName, depth + 1, seq, splits_i);
+    );
+
+    donePath := concatenate(doneDir, "/", itemName);
+    copyFile(itemPath, donePath);
+    removeFile itemPath;
+
+    emitItemDone(itemName, #splits);
+    #splits
+);
+
 -- Initializes the queue directory structure under outputDir.
 -- First run: creates pending/ and done/, seeds pending/ with one file per
 --   triangulation from inputFile (zero-padded sequence filenames, depth 0, parent "seed").
@@ -95,4 +153,41 @@ TEST ///
   assert(item#"parent" === "seed")
   assert(item#"depth" === 0)
   assert(item#"seq" === 1)
+///
+
+TEST ///
+  -- processQueueItem moves the processed item from pending/ to done/
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pendingDir := concatenate(tmpBase, "/pending");
+  doneDir := concatenate(tmpBase, "/done");
+  mkdir pendingDir;
+  mkdir doneDir;
+  tri := (value get "data/surface triangulations/irredTori.m2")_0;
+  writeQueueItem(concatenate(pendingDir, "/0001"), "seed", 0, 1, tri);
+  processQueueItem(pendingDir, doneDir);
+  doneFiles := select(readDirectory doneDir, f -> f != "." and f != "..");
+  assert(#doneFiles == 1)
+  pendingFilenames := select(readDirectory pendingDir, f -> f != "." and f != "..");
+  assert(not member("0001", pendingFilenames))
+///
+
+TEST ///
+  -- splits produced by processQueueItem have parent set to the source item filename
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pendingDir := concatenate(tmpBase, "/pending");
+  doneDir := concatenate(tmpBase, "/done");
+  mkdir pendingDir;
+  mkdir doneDir;
+  toriAll := value get "data/surface triangulations/irredTori.m2";
+  tri := toriAll_0;
+  writeQueueItem(concatenate(pendingDir, "/0001"), "seed", 0, 1, tri);
+  processQueueItem(pendingDir, doneDir);
+  splitFiles := sort select(readDirectory pendingDir, f -> f != "." and f != "..");
+  for fName in splitFiles do (
+      splitItem := readQueueItem concatenate(pendingDir, "/", fName);
+      assert(splitItem#"parent" === "0001");
+      assert(splitItem#"depth" === 1);
+  );
 ///

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -38,14 +38,14 @@ nextQueueSeq = (pendingDir, doneDir) -> (
     else max(apply(allFiles, f -> value f)) + 1
 );
 
--- Emits a run_paused event to stdout (cap hit before queue emptied).
+-- Emits a run_paused event to stderr (unbuffered; cap hit before queue emptied).
 emitRunPaused = () -> (
-    stdio << "EVENT:{\"type\":\"run_paused\"}" << endl;
+    stderr << "EVENT:{\"type\":\"run_paused\"}" << endl;
 );
 
--- Emits a run_complete event to stdout (queue emptied naturally).
+-- Emits a run_complete event to stderr (unbuffered; queue emptied naturally).
 emitRunComplete = () -> (
-    stdio << "EVENT:{\"type\":\"run_complete\"}" << endl;
+    stderr << "EVENT:{\"type\":\"run_complete\"}" << endl;
 );
 
 -- Runs the queue loop until pending/ is empty or a batch cap is hit.
@@ -94,16 +94,16 @@ runQueue = {
     status
 );
 
--- Emits a structured item_started event to stdout.
+-- Emits a structured item_started event to stderr (unbuffered).
 emitItemStarted = (itemName, depth, parent) -> (
-    stdio << "EVENT:{\"type\":\"item_started\",\"item\":\"" | itemName |
+    stderr << "EVENT:{\"type\":\"item_started\",\"item\":\"" | itemName |
         "\",\"depth\":" | toString depth |
         ",\"parent\":\"" | parent | "\"}" << endl;
 );
 
--- Emits a structured item_done event to stdout.
+-- Emits a structured item_done event to stderr (unbuffered).
 emitItemDone = (itemName, splitCount) -> (
-    stdio << "EVENT:{\"type\":\"item_done\",\"item\":\"" | itemName |
+    stderr << "EVENT:{\"type\":\"item_done\",\"item\":\"" | itemName |
         "\",\"splits\":" | toString splitCount | "}" << endl;
 );
 

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -38,6 +38,62 @@ nextQueueSeq = (pendingDir, doneDir) -> (
     else max(apply(allFiles, f -> value f)) + 1
 );
 
+-- Emits a run_paused event to stdout (cap hit before queue emptied).
+emitRunPaused = () -> (
+    stdio << "EVENT:{\"type\":\"run_paused\"}" << endl;
+);
+
+-- Emits a run_complete event to stdout (queue emptied naturally).
+emitRunComplete = () -> (
+    stdio << "EVENT:{\"type\":\"run_complete\"}" << endl;
+);
+
+-- Runs the queue loop until pending/ is empty or a batch cap is hit.
+-- Optional caps (all nullable — null means uncapped):
+--   itemCap        => ZZ    : stop after processing this many items
+--   maxVertexCount => ZZ    : stop before processing an item whose triangulation
+--                             has more vertices than this threshold
+--   timeoutSeconds => ZZ    : wall-clock timeout in seconds (soft — never mid-item)
+--   exemptions     => HashTable : passed through to processQueueItem
+-- Returns "complete" if queue emptied, "paused" if a cap stopped the run.
+runQueue = {
+    itemCap => null,
+    maxVertexCount => null,
+    timeoutSeconds => null,
+    exemptions => new HashTable from {}
+} >> opts -> (pendingDir, doneDir) -> (
+    startTime := currentTime();
+    itemsProcessed := 0;
+    status := "complete";
+    running := true;
+    while running do (
+        pendingFiles := sort select(readDirectory pendingDir, f -> f != "." and f != "..");
+        if #pendingFiles == 0 then (
+            running = false;
+        ) else (
+            shouldPause := false;
+            if opts.itemCap =!= null and itemsProcessed >= opts.itemCap then (
+                shouldPause = true;
+            ) else if opts.timeoutSeconds =!= null and currentTime() - startTime >= opts.timeoutSeconds then (
+                shouldPause = true;
+            ) else if opts.maxVertexCount =!= null then (
+                nextItem := readQueueItem concatenate(pendingDir, "/", pendingFiles_0);
+                if #(getVertices nextItem#"triangulation") > opts.maxVertexCount then
+                    shouldPause = true;
+            );
+            if shouldPause then (
+                status = "paused";
+                running = false;
+            ) else (
+                processQueueItem(pendingDir, doneDir, exemptions => opts.exemptions);
+                itemsProcessed = itemsProcessed + 1;
+            );
+        );
+    );
+    if status === "complete" then emitRunComplete() else emitRunPaused();
+    status
+);
+
 -- Emits a structured item_started event to stdout.
 emitItemStarted = (itemName, depth, parent) -> (
     stdio << "EVENT:{\"type\":\"item_started\",\"item\":\"" | itemName |
@@ -190,4 +246,37 @@ TEST ///
       assert(splitItem#"parent" === "0001");
       assert(splitItem#"depth" === 1);
   );
+///
+
+TEST ///
+  -- runQueue with itemCap=1 processes exactly 1 item then returns "paused"
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pendingDir := concatenate(tmpBase, "/pending");
+  doneDir := concatenate(tmpBase, "/done");
+  mkdir pendingDir;
+  mkdir doneDir;
+  toriAll := value get "data/surface triangulations/irredTori.m2";
+  for i from 0 to 2 do
+      writeQueueItem(concatenate(pendingDir, "/", queueSeqStr(i+1, 4)), "seed", 0, i+1, toriAll_i);
+  result := runQueue(pendingDir, doneDir, itemCap => 1);
+  assert(result === "paused")
+  doneFiles := select(readDirectory doneDir, f -> f != "." and f != "..");
+  assert(#doneFiles == 1)
+///
+
+TEST ///
+  -- runQueue runs to convergence: pending/ empties and returns "complete"
+  -- Uses the 10-vertex irreducible torus (index 21), which converges quickly.
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  pendingDir := concatenate(tmpBase, "/pending");
+  doneDir := concatenate(tmpBase, "/done");
+  mkdir pendingDir;
+  mkdir doneDir;
+  tri10v := (value get "data/surface triangulations/irredTori.m2")_20;
+  writeQueueItem(concatenate(pendingDir, "/0001"), "seed", 0, 1, tri10v);
+  result := runQueue(pendingDir, doneDir);
+  assert(result === "complete")
+  assert(0 == #select(readDirectory pendingDir, f -> f != "." and f != ".."))
 ///

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -289,15 +289,15 @@ TEST ///
   -- "unknown key or option" error at the call site.
   tmpBase := temporaryFileName();
   mkdir tmpBase;
-  pd := concatenate(tmpBase, "/pending");
-  dd := concatenate(tmpBase, "/done");
-  mkdir pd; mkdir dd;
+  testPendingDir := concatenate(tmpBase, "/pending");
+  testDoneDir    := concatenate(tmpBase, "/done");
+  mkdir testPendingDir; mkdir testDoneDir;
   toriAll := value get "data/surface triangulations/irredTori.m2";
-  writeQueueItem(concatenate(pd, "/0001"), "seed", 0, 1, toriAll_0);
+  writeQueueItem(concatenate(testPendingDir, "/0001"), "seed", 0, 1, toriAll_0);
   capItem := 1;
   capMaxVerts := null;
   capTimeout := null;
-  result := runQueue(pd, dd,
+  result := runQueue(testPendingDir, testDoneDir,
       itemCap => capItem, maxVertexCount => capMaxVerts,
       timeoutSeconds => capTimeout, exemptions => new HashTable from {});
   assert(result === "paused")

--- a/libs.m2
+++ b/libs.m2
@@ -10,6 +10,7 @@ load "lib/vertexSplit.m2"
 load "lib/criticalRegions.m2"
 load "lib/polynomialSimpcomp.m2"
 load "lib/analyzeIteration.m2"
+load "lib/queueOps.m2"
 
 -- Default no-op logging stubs. The analysis runtime (runAnalysis.m2) overrides these
 -- with file-writing implementations. These stubs ensure library functions work in

--- a/scripts/initQueueEnv.m2
+++ b/scripts/initQueueEnv.m2
@@ -3,14 +3,13 @@
 --
 -- Expects globals set by the caller (e.g. runItem.m2 or a config file):
 --   analysisName      -- string: name of this analysis run
+--   analysisOutputDir -- string: absolute path to the run output directory
 --   analysisInputFile -- string: absolute path to the initial triangulations file
 --
 -- Sets global used by subsequent scripts:
 --   outputDirPath -- string: path to the run output directory
 
-ANALYSIS'OUTPUT'FOLDER = "analysis output";
-try mkdir ANALYSIS'OUTPUT'FOLDER;
-outputDirPath = concatenate(ANALYSIS'OUTPUT'FOLDER, "/", analysisName);
+outputDirPath = analysisOutputDir;
 if not isDirectory outputDirPath then mkdir outputDirPath;
 
 initQueue(outputDirPath, analysisInputFile);

--- a/scripts/initQueueEnv.m2
+++ b/scripts/initQueueEnv.m2
@@ -1,0 +1,16 @@
+-- Initializes the queue environment for iterative analysis.
+-- Replaces initAnalysisEnv.m2.
+--
+-- Expects globals set by the caller (e.g. runItem.m2 or a config file):
+--   analysisName      -- string: name of this analysis run
+--   analysisInputFile -- string: absolute path to the initial triangulations file
+--
+-- Sets global used by subsequent scripts:
+--   outputDirPath -- string: path to the run output directory
+
+ANALYSIS'OUTPUT'FOLDER = "analysis output";
+try mkdir ANALYSIS'OUTPUT'FOLDER;
+outputDirPath = concatenate(ANALYSIS'OUTPUT'FOLDER, "/", analysisName);
+if not isDirectory outputDirPath then mkdir outputDirPath;
+
+initQueue(outputDirPath, analysisInputFile);

--- a/scripts/runItem.m2
+++ b/scripts/runItem.m2
@@ -1,0 +1,30 @@
+-- Processes one item from the analysis queue.
+-- Usage: M2 --script scripts/runItem.m2 /absolute/path/to/config.m2
+--
+-- Config file must set:
+--   analysisName      -- string: name of this analysis run
+--   analysisInputFile -- string: absolute path to initial triangulations file
+
+load (scriptCommandLine)_1;
+
+libsLoaded := false;
+try (load "libs.m2"; libsLoaded = true);
+if not libsLoaded then (stderr << "error: failed to load libs.m2" << endl; exit 2);
+
+envLoaded := false;
+try (load "scripts/initQueueEnv.m2"; envLoaded = true);
+if not envLoaded then (stderr << "error: failed to initialize queue environment" << endl; exit 2);
+
+kbExemptSplits := value get "data/surface triangulations/kbExemptSplits.m2";
+
+pendingDir := concatenate(outputDirPath, "/pending");
+doneDir := concatenate(outputDirPath, "/done");
+
+pendingFiles := select(readDirectory pendingDir, f -> f != "." and f != "..");
+if #pendingFiles == 0 then (
+    stderr << "queue is empty" << endl;
+    exit 0;
+);
+
+processQueueItem(pendingDir, doneDir, exemptions => kbExemptSplits);
+exit 0;

--- a/scripts/runQueue.m2
+++ b/scripts/runQueue.m2
@@ -1,0 +1,44 @@
+-- Queue orchestrator: processes items from the analysis queue until empty or a cap is hit.
+-- Usage: M2 --script scripts/runQueue.m2 /absolute/path/to/config.m2 [itemCap] [maxVertexCount] [timeoutSeconds]
+--
+-- Config file must set:
+--   analysisName      -- string: name of this analysis run
+--   analysisInputFile -- string: absolute path to initial triangulations file
+--
+-- Batch cap arguments (positional, pass "null" to skip a cap):
+--   itemCap        -- integer: max items to process this invocation
+--   maxVertexCount -- integer: stop before processing items with more vertices than this
+--   timeoutSeconds -- integer: wall-clock timeout in seconds (soft — never mid-item)
+
+load (scriptCommandLine)_1;
+
+libsLoaded := false;
+try (load "libs.m2"; libsLoaded = true);
+if not libsLoaded then (stderr << "error: failed to load libs.m2" << endl; exit 2);
+
+envLoaded := false;
+try (load "scripts/initQueueEnv.m2"; envLoaded = true);
+if not envLoaded then (stderr << "error: failed to initialize queue environment" << endl; exit 2);
+
+kbExemptSplits := value get "data/surface triangulations/kbExemptSplits.m2";
+
+parseCapArg = argIdx -> (
+    if #scriptCommandLine <= argIdx then null
+    else if (scriptCommandLine)_argIdx == "null" then null
+    else value((scriptCommandLine)_argIdx)
+);
+
+itemCap        := parseCapArg 2;
+maxVertexCount := parseCapArg 3;
+timeoutSeconds := parseCapArg 4;
+
+pendingDir := concatenate(outputDirPath, "/pending");
+doneDir    := concatenate(outputDirPath, "/done");
+
+runQueue(pendingDir, doneDir,
+    itemCap        => itemCap,
+    maxVertexCount => maxVertexCount,
+    timeoutSeconds => timeoutSeconds,
+    exemptions     => kbExemptSplits);
+
+exit 0;

--- a/scripts/runQueue.m2
+++ b/scripts/runQueue.m2
@@ -28,17 +28,17 @@ parseCapArg = argIdx -> (
     else value((scriptCommandLine)_argIdx)
 );
 
-itemCap        := parseCapArg 2;
-maxVertexCount := parseCapArg 3;
-timeoutSeconds := parseCapArg 4;
+capItem     := parseCapArg 2;
+capMaxVerts := parseCapArg 3;
+capTimeout  := parseCapArg 4;
 
 pendingDir := concatenate(outputDirPath, "/pending");
 doneDir    := concatenate(outputDirPath, "/done");
 
 runQueue(pendingDir, doneDir,
-    itemCap        => itemCap,
-    maxVertexCount => maxVertexCount,
-    timeoutSeconds => timeoutSeconds,
+    itemCap        => capItem,
+    maxVertexCount => capMaxVerts,
+    timeoutSeconds => capTimeout,
     exemptions     => kbExemptSplits);
 
 exit 0;


### PR DESCRIPTION
## Summary

- Adds `lib/queueOps.m2` — queue orchestration logic with batch caps and job lifecycle management
- Adds `scripts/runQueue.m2`, `scripts/runItem.m2`, `scripts/initQueueEnv.m2` — entry point scripts for queue-driven analysis
- Updates `libs.m2` to load `queueOps`
- Updates README to document `runQueue.m2` as primary entry point

Closes #45

## Test plan

- [ ] Load package and run `check "ext-shifting"` in M2 terminal
- [ ] Verify queue processes items in batch-capped order
- [ ] Verify EVENT: lines route through stderr for immediate flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)