### PR TITLE
fix #62 #63: graceful stop signal + live queue state (M2 layer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /analysis v2/
 /analysis output/
 analysis config.m2
+/run-configs/
+/output/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The queue-based analysis stores each pending triangulation as its own file, so i
    ```
    analysisName = "tori-analysis"
    analysisInputFile = "/absolute/path/to/data/surface triangulations/irredTori.m2"
+   analysisOutputDir = "/absolute/path/to/analysis output/tori-analysis"
    ```
 
 2. Run the queue orchestrator from the root of the cloned repository:

--- a/lib/queueOps.m2
+++ b/lib/queueOps.m2
@@ -66,7 +66,16 @@ runQueue = {
     itemsProcessed := 0;
     status := "complete";
     running := true;
+    -- Run directory is the parent of pendingDir (pendingDir ends with "/pending")
+    runDirPath := substring(pendingDir, 0, #pendingDir - #"/pending");
     while running do (
+        -- Check for graceful stop signal written by C# Stop() before processing next item
+        stopSignalPath := concatenate(runDirPath, "/stop_requested");
+        if fileExists stopSignalPath then (
+            removeFile stopSignalPath;
+            status = "paused";
+            running = false;
+        ) else (
         pendingFiles := sort select(readDirectory pendingDir, f -> f != "." and f != "..");
         if #pendingFiles == 0 then (
             running = false;
@@ -89,6 +98,7 @@ runQueue = {
                 itemsProcessed = itemsProcessed + 1;
             );
         );
+        ); -- end stop-signal else branch
     );
     if status === "complete" then emitRunComplete() else emitRunPaused();
     status
@@ -315,4 +325,26 @@ TEST ///
   assert(outputDirPath === tmpBase)
   assert(isDirectory concatenate(tmpBase, "/pending"))
   assert(isDirectory concatenate(tmpBase, "/done"))
+///
+
+TEST ///
+  -- runQueue halts before processing any item when stop_requested signal file is present
+  -- Signal file is consumed (deleted) and status returned is "paused"
+  tmpBase := temporaryFileName();
+  mkdir tmpBase;
+  testPendingDir := concatenate(tmpBase, "/pending");
+  testDoneDir    := concatenate(tmpBase, "/done");
+  mkdir testPendingDir; mkdir testDoneDir;
+  toriAll := value get "data/surface triangulations/irredTori.m2";
+  writeQueueItem(concatenate(testPendingDir, "/0001"), "seed", 0, 1, toriAll_0);
+  writeQueueItem(concatenate(testPendingDir, "/0002"), "seed", 0, 2, toriAll_1);
+  -- Write stop_requested signal in run directory (parent of pending/)
+  concatenate(tmpBase, "/stop_requested") << "" << close;
+  result := runQueue(testPendingDir, testDoneDir);
+  assert(result === "paused")
+  -- Signal file must be deleted after being consumed
+  assert(not fileExists concatenate(tmpBase, "/stop_requested"))
+  -- No items should have been processed
+  doneFiles := select(readDirectory testDoneDir, f -> f != "." and f != "..");
+  assert(#doneFiles == 0)
 ///

--- a/scripts/initQueueEnv.m2
+++ b/scripts/initQueueEnv.m2
@@ -10,6 +10,10 @@
 --   outputDirPath -- string: path to the run output directory
 
 outputDirPath = analysisOutputDir;
-if not isDirectory outputDirPath then mkdir outputDirPath;
+if not isDirectory outputDirPath then (
+    parentDir := replace("/[^/]*$", "", outputDirPath);
+    if parentDir != outputDirPath and not isDirectory parentDir then mkdir parentDir;
+    mkdir outputDirPath;
+);
 
 initQueue(outputDirPath, analysisInputFile);


### PR DESCRIPTION
## Summary

- **#62 — graceful stop**: `queueOps.m2` now checks for a `stop_requested` file between items; M2 finishes the current item, emits `run_paused`, and exits cleanly rather than being hard-killed mid-computation
- **initQueueEnv.m2**: auto-creates the parent directory so manual WSL runs work without pre-creating `analysis output/`
- **docs**: adds `analysisOutputDir` to the config example in `README.md`
- **gitignore**: ignores `/run-configs/` and `/output/`

## Test plan

- [ ] Load `ext-shifting` in M2 and run `check "ext-shifting"` — all tests pass
- [ ] Start a queue run, call stop mid-item; verify M2 finishes the in-flight item before exiting
- [ ] Verify `stop_requested` file is consumed/deleted after M2 exits