### PR TITLE
feat: add M2 integration test scripts for iterative analysis termination

### DIFF
--- a/tests/testKleinBottle.m2
+++ b/tests/testKleinBottle.m2
@@ -1,0 +1,20 @@
+-- Test: iterative analysis on a random irreducible Klein bottle triangulation never exceeds 12 vertices.
+-- Performs a sampled walk of up to 10 steps from a random seed triangulation.
+-- N = 12 confirmed by prior manual runs.
+-- Run from m2/ext-shifting/ in an M2 terminal:
+--   load "tests/testKleinBottle.m2"
+load "libs.m2";
+
+irredKb := value get "data/surface triangulations/irredKb.m2";
+current := irredKb_(random(#irredKb));
+
+for i from 0 to 9 do (
+    result := analyzeIteration({current});
+    largest := result#2;
+    splits := result#1;
+    assert(largest <= 12);
+    if #splits == 0 then break;
+    current = splits_(random(#splits));
+);
+
+print "testKleinBottle: PASSED"

--- a/tests/testProjectivePlane.m2
+++ b/tests/testProjectivePlane.m2
@@ -1,0 +1,16 @@
+-- Test: analyzeIteration on both irreducible projective plane triangulations returns empty splits.
+-- The projective plane has exactly 2 irreducible triangulations (6 vertices each).
+-- Both should produce zero splits from analyzeIteration, confirming immediate termination.
+-- Run from m2/ext-shifting/ in an M2 terminal:
+--   load "tests/testProjectivePlane.m2"
+load "libs.m2";
+
+irredPp := value get "data/surface triangulations/irredPp.m2";
+
+result0 := analyzeIteration({irredPp_0});
+assert(#(result0#1) == 0)
+
+result1 := analyzeIteration({irredPp_1});
+assert(#(result1#1) == 0)
+
+print "testProjectivePlane: PASSED"

--- a/tests/testTorus.m2
+++ b/tests/testTorus.m2
@@ -1,0 +1,20 @@
+-- Test: iterative analysis on a random irreducible torus triangulation never exceeds 10 vertices.
+-- Performs a sampled walk of up to 10 steps from a random seed triangulation.
+-- N = 10 confirmed by prior manual runs.
+-- Run from m2/ext-shifting/ in an M2 terminal:
+--   load "tests/testTorus.m2"
+load "libs.m2";
+
+irredTori := value get "data/surface triangulations/irredTori.m2";
+current := irredTori_(random(#irredTori));
+
+for i from 0 to 9 do (
+    result := analyzeIteration({current});
+    largest := result#2;
+    splits := result#1;
+    assert(largest <= 10);
+    if #splits == 0 then break;
+    current = splits_(random(#splits));
+);
+
+print "testTorus: PASSED"


### PR DESCRIPTION
## Summary

- Adds `tests/testTorus.m2` — sampled-walk test verifying torus iterative analysis never exceeds 10 vertices
- Adds `tests/testKleinBottle.m2` — same for Klein bottle with bound of 12 vertices
- Adds `tests/testProjectivePlane.m2` — verifies both irreducible projective plane triangulations produce zero splits (immediate termination)

These scripts are invoked automatically by the C# `M2IntegrationTests` suite in the app repo via `WslAwareM2Runner`. Each script uses `assert` for failure signalling so M2 exits non-zero on failure, which the C# runner detects.

Related: ank1494/ext-shifting-app#70, ank1494/ext-shifting-app#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)