### PR TITLE
fix(#26): move exemptSplits filter to post-classification handoff

### DIFF
--- a/lib/criticalRegions.m2
+++ b/lib/criticalRegions.m2
@@ -83,9 +83,8 @@ getCritRegions = {exemptSplits => {}} >> opts -> (srfc, finalEdge) -> (
     critRegStrs := set {};
     nextCplxes := {};
 
-    -- Compute non-trivial vertex splits; filter exempt splits before shift computation.
+    -- Compute non-trivial vertex splits.
     rawSplits := nonTrivialVertexSplits srfc;
-    rawSplits = select(rawSplits, pair -> (vsd := pair_1; not member({vsd.base, vsd.neighbors}, opts.exemptSplits)));
     splits := {};
     for i from 0 to #rawSplits - 1 do (
         splitComplex := rawSplits_i_0;
@@ -196,6 +195,10 @@ getCritRegions = {exemptSplits => {}} >> opts -> (srfc, finalEdge) -> (
         );
 
         logInfo concatenate("regions count: ", toString regionsCount);
+
+        -- Filter exempt splits from the handoff only — they participated in critical region
+        -- classification above but should not be passed to the next iteration.
+        remainingSplits = select(remainingSplits, split -> not member({split.splitData.base, split.splitData.neighbors}, opts.exemptSplits));
 
         -- Vertex splits outside critical regions that still have the same final edge
         -- need to be processed in the next iteration.


### PR DESCRIPTION
Closes #26

## Summary
- Removes the early `exemptSplits` filter that was applied before shift computation and critical region classification
- Adds the filter to `remainingSplits` immediately before the `badSplits` error check, so exempted splits are excluded from the next-iteration handoff only
- Updates the comment to reflect the correct semantic

## Why
The intended semantic of `exemptSplits` is to exclude splits from the next-iteration handoff, not from critical region computation. The old ordering made exempted splits invisible to the `all(splitsFromV, split -> split.preservesFinalEdge)` critical vertex test, which would produce incorrect critical region classification once automorphism-aware split filtering is introduced.

## Test plan
- [x] `CriticalRegions_Structure_Passes`
- [x] `CriticalRegions_Kb25_Passes`
- [x] `AnalyzeIteration_Kb25_Passes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)