### PR TITLE
feat(#99): add intermediateVertices to VertexSplitData; ratio-2 dedup filter

### DIFF
--- a/ExtShifting.m2
+++ b/ExtShifting.m2
@@ -40,7 +40,7 @@ export {
     "isSameSideSplit", "getCritRegions",
     "exemptSplits",
     -- HashTable key symbols for VertexSplitData fields
-    "base", "neighbors", "ratio",
+    "base", "neighbors", "ratio", "intermediateVertices",
     -- HashTable key symbols for ShiftAnnotatedSplit fields
     "splitData", "preservesFinalEdge", "noVertex4",
     -- HashTable key symbols for CritRegionsResult fields

--- a/lib/criticalRegions.m2
+++ b/lib/criticalRegions.m2
@@ -196,6 +196,19 @@ getCritRegions = {exemptSplits => {}} >> opts -> (srfc, finalEdge) -> (
 
         logInfo concatenate("regions count: ", toString regionsCount);
 
+        -- Ratio-2 deduplication: a split at base with ratio_0==2 and intermediate vertex u is
+        -- isomorphic to the split at u; keep only the one with the lower base index.
+        -- Exception: if either endpoint has degree 4 it won't appear in the other's handoff anyway.
+        deg := v -> #(select(srfc, t -> member(v, t)));
+        remainingSplits = select(remainingSplits, split -> (
+            data := split.splitData;
+            iv0 := (data.intermediateVertices)_0;
+            not ((data.ratio)_0 == 2
+                and data.base > iv0_0
+                and deg(data.base) > 4
+                and deg(iv0_0) > 4)
+        ));
+
         -- Filter exempt splits from the handoff only — they participated in critical region
         -- classification above but should not be passed to the next iteration.
         remainingSplits = select(remainingSplits, split -> not member({split.splitData.base, split.splitData.neighbors}, opts.exemptSplits));
@@ -252,6 +265,31 @@ TEST ///
     assert(#pair == 2);
     assert(instance(pair_1, VertexSplitData));
   );
+///
+
+TEST ///
+  -- Ratio-2 filter: for any irreducible triangulation, each undirected edge {v,u} with both
+  -- endpoints degree > 4 contributes exactly one discardable ratio-2 split (the one at the
+  -- higher-indexed base). If either endpoint has degree 4 it is exempt (caught as a critical region).
+  irredTori := value get "data/surface triangulations/irredTori.m2";
+  irredPp   := value get "data/surface triangulations/irredPp.m2";
+  irredKb   := value get "data/surface triangulations/irredKb.m2";
+  -- Restrict to ≤8 vertices so nonTrivialVertexSplits stays within the GC cap.
+  smallTris := select(join(irredTori, irredPp, irredKb), tri -> #(getVertices tri) <= 8);
+  tri := smallTris_(random #smallTris);
+  allSplits := nonTrivialVertexSplits tri;
+  deg := v -> #(select(tri, t -> member(v, t)));
+  isDiscardable := split -> (
+    data := split_1;
+    iv0 := (data.intermediateVertices)_0;
+    (data.ratio)_0 == 2 and data.base > iv0_0 and deg(data.base) > 4 and deg(iv0_0) > 4
+  );
+  filteredSplits := select(allSplits, split -> not isDiscardable split);
+  -- Expected: one discarded split per edge where both endpoints have degree > 4
+  edges := getEdges tri;
+  expectedDiscarded := #(select(edges, edge -> deg(edge_0) > 4 and deg(edge_1) > 4));
+  assert(#filteredSplits == #allSplits - expectedDiscarded)
+  assert(all(filteredSplits, split -> not isDiscardable split))
 ///
 
 -- Tests for getCritRegions on irredKb_25 (10-vertex Klein bottle) have been moved to

--- a/lib/criticalRegions.m2
+++ b/lib/criticalRegions.m2
@@ -276,7 +276,7 @@ TEST ///
   irredKb   := value get "data/surface triangulations/irredKb.m2";
   -- Restrict to ≤8 vertices so nonTrivialVertexSplits stays within the GC cap.
   smallTris := select(join(irredTori, irredPp, irredKb), tri -> #(getVertices tri) <= 8);
-  tri := smallTris_(random #smallTris);
+  tri := smallTris_(random (#smallTris));
   allSplits := nonTrivialVertexSplits tri;
   deg := v -> #(select(tri, t -> member(v, t)));
   isDiscardable := split -> (

--- a/lib/vertexSplit.m2
+++ b/lib/vertexSplit.m2
@@ -2,7 +2,8 @@
 
 -- Typed record for the geometry of a non-trivial vertex split.
 -- Fields: base (the split vertex), neighbors (the two boundary neighbors that define the split arc),
---         ratio (sorted pair of triangle counts on each side of the split).
+--         ratio (sorted pair of triangle counts on each side of the split, smaller first),
+--         intermediateVertices (pair of intermediate vertex lists, smaller list first, mirroring ratio).
 VertexSplitData = new Type of HashTable
 
 doc ///
@@ -105,8 +106,16 @@ nonTrivialSplitsAtVertex0 = cplx -> (
 			newTriangle = append(delete(0, triangles_j), newVertex);
 			tempCplx = append(tempCplx, newTriangle);
 			toAdd := append(tempCplx, {0, endVertex, newVertex});
-			infoString := splitInfoString(startVertex, endVertex, triangleCount, trianglesLength - triangleCount);
-			infoList := splitInfoList(startVertex, endVertex, triangleCount, trianglesLength - triangleCount);
+			-- Intermediate vertices on each side (excluding base and the two boundary neighbors).
+			-- Arc side: positions i+1..j; complement side: positions j+2..(i-1) wrapping.
+			complLen := trianglesLength - triangleCount - 1;
+			arcIntermediates := apply(j - i, k -> vertexCycle_(i + 1 + k));
+			complementIntermediates := apply(complLen, k -> vertexCycle_((j + 2 + k) % trianglesLength));
+			intermediates := if triangleCount <= trianglesLength - triangleCount
+			    then {arcIntermediates, complementIntermediates}
+			    else {complementIntermediates, arcIntermediates};
+			infoString := splitInfoString(startVertex, endVertex, triangleCount, trianglesLength - triangleCount, intermediates);
+			infoList := splitInfoList(startVertex, endVertex, triangleCount, trianglesLength - triangleCount, intermediates);
 			splits = append(splits, toList {toAdd, infoList});
 		);
 	);
@@ -132,15 +141,17 @@ doc ///
 -- Returns a list of {resultComplex, VertexSplitData} pairs in original vertex coordinates.
 nonTrivialVertexSplits = complex -> (
 	currentSplitBase := 0;
-	splitInfoString = (startV, endV, side1, side2) -> (
+	splitInfoString = (startV, endV, side1, side2, intermediates) -> (
 		startV = if startV == currentSplitBase then 0 else startV;
 		endV = if endV == currentSplitBase then 0 else endV;
 		concatenate("base:", toString currentSplitBase, ", neighbors:", toString {startV, endV}, ", triangle ratio:", toString sort {side1, side2})
 	);
-	splitInfoList = (startV, endV, side1, side2) -> (
+	splitInfoList = (startV, endV, side1, side2, intermediates) -> (
 		startV = if startV == currentSplitBase then 0 else startV;
 		endV = if endV == currentSplitBase then 0 else endV;
-		new VertexSplitData from { base => currentSplitBase, neighbors => sort {startV, endV}, ratio => sort {side1, side2} }
+		-- Swap the base vertex label back in intermediate vertex lists (base was relabeled to 0).
+		intermediates = intermediates / (lst -> lst / (v -> if v == currentSplitBase then 0 else v));
+		new VertexSplitData from { base => currentSplitBase, neighbors => sort {startV, endV}, ratio => sort {side1, side2}, intermediateVertices => intermediates }
 	);
 	result := {};
 	vertices := getVertices complex;
@@ -250,6 +261,29 @@ doc ///
   Description
     Example
       contractCplx({{0,1,2},{0,2,3}}, {0,1})
+///
+
+TEST ///
+  -- Fan triangulation: hub vertex 1, rim 2..n. Vertex 1's cycle is [2,3,...,n].
+  n := 6;
+  fanTriangles := join(apply(toList(2..(n-1)), i -> {1,i,i+1}), {{1,2,n}});
+  splits := nonTrivialVertexSplits fanTriangles;
+  splitsAtV1 := select(splits, pair -> (pair_1).base == 1);
+  -- intermediateVertices sizes mirror ratio: iv_0 has ratio_0-1 elements, iv_1 has ratio_1-1
+  assert(all(splitsAtV1, pair -> (
+    iv := (pair_1).intermediateVertices;
+    r := (pair_1).ratio;
+    #iv == 2 and #(iv_0) == r_0 - 1 and #(iv_1) == r_1 - 1
+  )));
+  -- intermediateVertices cover exactly the non-neighbor rim vertices
+  assert(all(splitsAtV1, pair -> (
+    data := pair_1;
+    iv := data.intermediateVertices;
+    nbrs := set data.neighbors;
+    allIntermediates := set join(iv_0, iv_1);
+    rimVerts := set toList(2..n);
+    allIntermediates === rimVerts - nbrs
+  )))
 ///
 
 TEST ///

--- a/lib/vertexSplit.m2
+++ b/lib/vertexSplit.m2
@@ -265,7 +265,7 @@ doc ///
 
 TEST ///
   -- Fan triangulation: hub vertex 1, rim 2..n. Vertex 1's cycle is [2,3,...,n].
-  n := 6;
+  n := random(6, 10);
   fanTriangles := join(apply(toList(2..(n-1)), i -> {1,i,i+1}), {{1,2,n}});
   splits := nonTrivialVertexSplits fanTriangles;
   splitsAtV1 := select(splits, pair -> (pair_1).base == 1);

--- a/tests/testKleinBottle.m2
+++ b/tests/testKleinBottle.m2
@@ -14,7 +14,7 @@ for i from 0 to 9 do (
     splits := result#1;
     assert(largest <= 12);
     if #splits == 0 then break;
-    current = splits_(random(#splits));
+    current = (splits_(random(#splits)))_0;
 );
 
 print "testKleinBottle: PASSED"

--- a/tests/testTorus.m2
+++ b/tests/testTorus.m2
@@ -14,7 +14,7 @@ for i from 0 to 9 do (
     splits := result#1;
     assert(largest <= 10);
     if #splits == 0 then break;
-    current = splits_(random(#splits));
+    current = (splits_(random(#splits)))_0;
 );
 
 print "testTorus: PASSED"


### PR DESCRIPTION
Closes ank1494/ext-shifting-app#99

## Summary

- **`lib/vertexSplit.m2`**: Add `intermediateVertices` field to `VertexSplitData` — a pair of intermediate vertex lists (one per side of the split, smaller list first, mirroring the `ratio` convention). Threads the new parameter through `splitInfoString`/`splitInfoList` and computes it from the vertex cycle positions during `nonTrivialSplitsAtVertex0`.
- **`lib/criticalRegions.m2`**: Add ratio-2 deduplication filter in `getCritRegions`, applied to the handoff before the existing exempt-splits filter. Discards a split when `ratio_0 == 2`, `base > u` (where `u` is the sole arc-side intermediate), and both endpoints have degree > 4.
- **`ExtShifting.m2`**: Export the new `intermediateVertices` symbol.

## Tests

- `lib/vertexSplit.m2` inline `TEST`: fan triangulation with hub vertex 1 and randomised rim size; asserts size and coverage of `intermediateVertices` lists for each non-trivial split at vertex 1.
- `lib/criticalRegions.m2` inline `TEST`: picks a random irreducible triangulation (≤8 vertices); asserts that exactly one split is discarded per edge where both endpoints have degree > 4, and that no remaining split satisfies the discard predicate.

## Test plan

- [ ] Run `dotnet test` in ext-shifting-app (M2 integration tests cover both new `TEST` blocks)