### PR TITLE
feat(#105): automorphism data files and verification tests

### DIFF
--- a/data/surface triangulations/kbAutomorphisms.m2
+++ b/data/surface triangulations/kbAutomorphisms.m2
@@ -1,0 +1,53 @@
+-- Automorphism group generators for the irreducible Klein bottles with non-trivial automorphism groups.
+-- Covers irredKb_0 through irredKb_4 and irredKb_25.
+-- irredKb_5 has a trivial automorphism group and is absent from this table.
+-- Permutations are in index-based list form: position i holds the image of vertex i.
+-- Cycle-notation comments above each generator are for human readability.
+-- Non-generating group elements are omitted; groupClosure computes the full group at runtime.
+
+irredKb := value get "data/surface triangulations/irredKb.m2";
+new HashTable from {
+
+    -- irredKb_0: 8-vertex Klein bottle. Automorphism group order 2.
+    irredKb_0 => {
+        -- (0 6)(1 5)(2 3)(4 7)
+        {6,5,3,2,7,1,0,4}
+    },
+
+    -- irredKb_1: 8-vertex Klein bottle. Automorphism group order 2.
+    irredKb_1 => {
+        -- (0 2)(3 6)(4 7)
+        {2,1,0,6,7,5,3,4}
+    },
+
+    -- irredKb_2: 8-vertex Klein bottle. Automorphism group order 8.
+    irredKb_2 => {
+        -- (2 7)(3 4)
+        {0,1,7,4,3,5,6,2},
+        -- (0 1)(3 4)(5 6)
+        {1,0,2,4,3,6,5,7},
+        -- (0 5)(1 6)(2 3 7 4)
+        {5,6,3,7,2,0,1,4}
+    },
+
+    -- irredKb_3: 8-vertex Klein bottle. Automorphism group order 2.
+    irredKb_3 => {
+        -- (1 2)(4 6)(5 7)
+        {0,2,1,3,6,7,4,5}
+    },
+
+    -- irredKb_4: 8-vertex Klein bottle. Automorphism group order 2.
+    irredKb_4 => {
+        -- (0 1)(3 7)(4 5)
+        {1,0,2,7,5,4,6,3}
+    },
+
+    -- irredKb_25: 10-vertex Klein bottle. Automorphism group order 6.
+    irredKb_25 => {
+        -- (0 1 2)(3 5 6)(4 7 8)
+        {1,2,0,5,7,6,3,8,4,9},
+        -- (3 4)(5 7)(6 8)
+        {0,1,2,4,3,7,8,5,6,9}
+    }
+
+}

--- a/data/surface triangulations/toriAutomorphisms.m2
+++ b/data/surface triangulations/toriAutomorphisms.m2
@@ -1,0 +1,52 @@
+-- Automorphism group generators for the irreducible tori with non-trivial automorphism groups.
+-- Covers irredTori_0 through irredTori_4.
+-- Permutations are in index-based list form: position i holds the image of vertex i.
+-- Cycle-notation comments above each generator are for human readability.
+-- Non-generating group elements are omitted; groupClosure computes the full group at runtime.
+
+irredTori := value get "data/surface triangulations/irredTori.m2";
+new HashTable from {
+
+    -- irredTori_0: 7-vertex minimal torus. Automorphism group order 42.
+    irredTori_0 => {
+        -- (0 1 6 3 2 4)
+        {1,6,4,2,0,5,3},
+        -- (0 2 1 5 3 4)
+        {2,5,1,4,0,3,6}
+    },
+
+    -- irredTori_1: 8-vertex torus. Automorphism group order 32.
+    irredTori_1 => {
+        -- (2 4)(3 6)
+        {0,1,4,6,2,5,3,7},
+        -- (1 7)(2 3)(4 6)
+        {0,7,3,2,6,5,4,1},
+        -- (0 2 7 6 5 4 1 3)
+        {2,3,7,0,1,4,5,6}
+    },
+
+    -- irredTori_2: 8-vertex torus. Automorphism group order 4 (Klein four-group).
+    irredTori_2 => {
+        -- (1 3)(2 6)
+        {0,3,6,1,4,5,2,7},
+        -- (0 5)(1 3)(4 7)
+        {5,3,2,1,7,0,6,4}
+    },
+
+    -- irredTori_3: 8-vertex torus. Automorphism group order 6.
+    irredTori_3 => {
+        -- (0 5)(1 4)(3 6)
+        {5,4,2,6,1,0,3,7},
+        -- (0 7 5)(1 2 4)
+        {7,2,4,3,1,0,6,5}
+    },
+
+    -- irredTori_4: 8-vertex torus. Automorphism group order 4 (Klein four-group).
+    irredTori_4 => {
+        -- (1 3)(2 4)
+        {0,3,4,1,2,5,6,7},
+        -- (1 2)(3 4)(5 7)
+        {0,2,1,4,3,7,6,5}
+    }
+
+}

--- a/tests/automorphisms-kb.m2
+++ b/tests/automorphisms-kb.m2
@@ -1,0 +1,53 @@
+load "libs.m2";
+irredKb := value get "data/surface triangulations/irredKb.m2";
+kbExempts := value get "data/surface triangulations/kbExemptSplits.m2";
+kbAuts := value get "data/surface triangulations/kbAutomorphisms.m2";
+
+splitPairs = tri -> toList apply(nonTrivialVertexSplits tri, s -> {(s_1)#base, (s_1)#neighbors});
+
+-- Lex less-than on equal-length integer lists.
+lexLt = (a, b) -> (
+    pos := select(0..#a-1, i -> a_i != b_i);
+    if #pos == 0 then false else a_(pos_0) < b_(pos_0)
+);
+
+expectedOrders := hashTable {
+    irredKb_0  => 2,
+    irredKb_1  => 2,
+    irredKb_2  => 8,
+    irredKb_3  => 2,
+    irredKb_4  => 2,
+    irredKb_25 => 6
+};
+
+for tri in {irredKb_0, irredKb_1, irredKb_2, irredKb_3, irredKb_4, irredKb_25} do (
+    gens := kbAuts#tri;
+    grp := groupClosure gens;
+
+    -- 1. Correct group order
+    assert(#grp == expectedOrders#tri);
+
+    -- 2. Every group element is an automorphism
+    assert(all(grp, g -> isAutomorphism(g, tri)));
+
+    -- 3. Automorphism-based exemptions have no violations.
+    -- For irredKb_25, {0,{1,2}} is exempt for topology reasons (connected-sum seam),
+    -- not automorphism reasons; exclude it so the automorphism check remains clean.
+    allSplts := splitPairs tri;
+    exemptSplts := kbExempts#tri;
+    autExemptSplts := delete({0,{1,2}}, exemptSplts);
+    assert(isExemptionValid(tri, gens, autExemptSplts, allSplts) === {});
+
+    -- 4. Every non-exempt split at an automorphism-covered base is the lex-minimum of its orbit.
+    -- Bases absent from the exemption table are excluded (retained for non-automorphism reasons).
+    nonExempt := toList(set allSplts - set exemptSplts);
+    exemptBases := set apply(exemptSplts, e -> e_0);
+    assert(all(select(nonExempt, r -> member(r_0, exemptBases)), r -> (
+        fr := {r_0} | r_1;
+        all(grp, g -> not lexLt({(applyPermutationToSplit(g,r))_0} | (applyPermutationToSplit(g,r))_1, fr))
+    )));
+
+    print("automorphisms-kb: PASSED for " | toString tri);
+);
+
+print "ALL automorphisms-kb TESTS PASSED"

--- a/tests/automorphisms-tori.m2
+++ b/tests/automorphisms-tori.m2
@@ -1,0 +1,50 @@
+load "libs.m2";
+irredTori := value get "data/surface triangulations/irredTori.m2";
+toriExempts := value get "data/surface triangulations/toriExemptSplits.m2";
+toriAuts := value get "data/surface triangulations/toriAutomorphisms.m2";
+
+splitPairs = tri -> toList apply(nonTrivialVertexSplits tri, s -> {(s_1)#base, (s_1)#neighbors});
+
+-- Lex less-than on equal-length integer lists.
+lexLt = (a, b) -> (
+    pos := select(0..#a-1, i -> a_i != b_i);
+    if #pos == 0 then false else a_(pos_0) < b_(pos_0)
+);
+
+expectedOrders := hashTable {
+    irredTori_0 => 42,
+    irredTori_1 => 32,
+    irredTori_2 => 4,
+    irredTori_3 => 6,
+    irredTori_4 => 4
+};
+
+for tri in {irredTori_0, irredTori_1, irredTori_2, irredTori_3, irredTori_4} do (
+    gens := toriAuts#tri;
+    grp := groupClosure gens;
+
+    -- 1. Correct group order
+    assert(#grp == expectedOrders#tri);
+
+    -- 2. Every group element is an automorphism
+    assert(all(grp, g -> isAutomorphism(g, tri)));
+
+    -- 3. Exemption table has no violations
+    allSplts := splitPairs tri;
+    exemptSplts := toriExempts#tri;
+    assert(isExemptionValid(tri, gens, exemptSplts, allSplts) === {});
+
+    -- 4. Every non-exempt split at an automorphism-covered base is the lex-minimum of its orbit.
+    -- Bases absent from the exemption table (e.g. retained for degree/topology reasons, not
+    -- automorphism reasons) are excluded from this check.
+    nonExempt := toList(set allSplts - set exemptSplts);
+    exemptBases := set apply(exemptSplts, e -> e_0);
+    assert(all(select(nonExempt, r -> member(r_0, exemptBases)), r -> (
+        fr := {r_0} | r_1;
+        all(grp, g -> not lexLt({(applyPermutationToSplit(g,r))_0} | (applyPermutationToSplit(g,r))_1, fr))
+    )));
+
+    print("automorphisms-tori: PASSED for " | toString tri);
+);
+
+print "ALL automorphisms-tori TESTS PASSED"


### PR DESCRIPTION
## Summary
- Adds `toriAutomorphisms.m2` and `kbAutomorphisms.m2`: automorphism generators for T0–T4, KB0–4, KB25
- Adds `tests/automorphisms-tori.m2` and `tests/automorphisms-kb.m2`: verify group order, isAutomorphism, isExemptionValid, and lex-min orbit invariant
- Stacked on #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)